### PR TITLE
Fix incorrect namespace in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ is already available in the package. This requires installing
 
 use Nascom\TeamleaderApiClient\Http\HttpClient\GuzzleHttpClient;
 
-$guzzle = new \Guzzle\Client(['base_uri' => 'https://www.teamleader.be/api/']);
+$guzzle = new \GuzzleHttp\Client(['base_uri' => 'https://www.teamleader.be/api/']);
 $httpClient = new GuzzleHttpClient($guzzle);
 ```
 


### PR DESCRIPTION
For the Guzzle client, the namespace \Guzzle\Client was used while should be \GuzzleHttp\Client